### PR TITLE
Fixes twitter and facebook links. Hides FB and Twit btns if no info

### DIFF
--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -22,7 +22,7 @@
                     currentState: function($route) {
                         return $route.current.params.state;
                     },
-                    representatives: function($route, StateService) {
+                    repArrays: function($route, StateService) {
                         //resolves $http request before loading controller/view
                         return StateService.getRepsByState($route.current.params.address+", "+$route.current.params.state);
                     }
@@ -36,7 +36,7 @@
                     currentState: function($route) {
                         return $route.current.params.state;
                     },
-                    representatives: function($route, StateService) {
+                    repArrays: function($route, StateService) {
                         return StateService.getRepsByState($route.current.params.state);
                     }
                 }

--- a/public/scripts/controllers/mapCtrl.js
+++ b/public/scripts/controllers/mapCtrl.js
@@ -8,8 +8,8 @@
 
         var vm = this;
         vm.setCurrentState = setCurrentState;
-        vm.showCurrentState = showCurrentState;
-        vm.showState = '';
+        vm.changeStateName = changeStateName;
+        vm.stateName = '';
         vm.showSpinner = false;
         vm.hideState = false;
 
@@ -20,8 +20,8 @@
             $scope.$apply();
         }
 
-        function showCurrentState(state) {
-            vm.showState = stateNames[state];
+        function changeStateName(state) {
+            vm.stateName = stateNames[state];
             $scope.$apply();
         }
 

--- a/public/scripts/controllers/stateCtrl.js
+++ b/public/scripts/controllers/stateCtrl.js
@@ -4,13 +4,11 @@
         .module('stateship')
         .controller('StateCtrl', StateCtrl);
 
-    var stateNames={al:"Alabama",ak:"Alaska",az:"Arizona",ar:"Arkansas",ca:"California",co:"Colorado",ct:"Connecticut",de:"Delaware",fl:"Florida",ga:"Georgia",hi:"Hawaii",id:"Idaho",il:"Illinois","in":"Indiana",ia:"Iowa",ks:"Kansas",ky:"Kentucky",la:"Louisiana",me:"Maine",md:"Maryland",ma:"Massachusetts",mi:"Michigan",mn:"Minnesota",ms:"Mississippi",mo:"Missouri",mt:"Montana",ne:"Nebraska",nv:"Nevada",nh:"New Hampshire",nj:"New Jersey",nm:"New Mexico",ny:"New York",nc:"North Carolina",nd:"North Dakota",oh:"Ohio",ok:"Oklahoma",or:"Oregon",pa:"Pennsylvania",ri:"Rhode Island",sc:"South Carolina",sd:"South Dakota",tn:"Tennessee",tx:"Texas",ut:"Utah",vt:"Vermont",na:"Virginia",wa:"Washington",wv:"West Virginia",wi:"Wisconsin",wy:"Wyoming"}
+    var stateNames={al:"Alabama",ak:"Alaska",az:"Arizona",ar:"Arkansas",ca:"California",co:"Colorado",ct:"Connecticut",de:"Delaware",fl:"Florida",ga:"Georgia",hi:"Hawaii",id:"Idaho",il:"Illinois","in":"Indiana",ia:"Iowa",ks:"Kansas",ky:"Kentucky",la:"Louisiana",me:"Maine",md:"Maryland",ma:"Massachusetts",mi:"Michigan",mn:"Minnesota",ms:"Mississippi",mo:"Missouri",mt:"Montana",ne:"Nebraska",nv:"Nevada",nh:"New Hampshire",nj:"New Jersey",nm:"New Mexico",ny:"New York",nc:"North Carolina",nd:"North Dakota",oh:"Ohio",ok:"Oklahoma",or:"Oregon",pa:"Pennsylvania",ri:"Rhode Island",sc:"South Carolina",sd:"South Dakota",tn:"Tennessee",tx:"Texas",ut:"Utah",vt:"Vermont",va:"Virginia",wa:"Washington",wv:"West Virginia",wi:"Wisconsin",wy:"Wyoming"}
 
-    function StateCtrl(currentState, representatives, StateService) {
+    function StateCtrl(currentState, repArrays, StateService) {
 
         var vm = this;
-        var repArrays = StateService.getRepArrays(); //an array of arrays: [national, state, local]
-        vm.reps = representatives;
         vm.nationalReps = repArrays[0];
         vm.stateReps = repArrays[1];
         vm.localReps = repArrays[2];

--- a/public/scripts/directives/map-directive/mapDirective.js
+++ b/public/scripts/directives/map-directive/mapDirective.js
@@ -8,7 +8,7 @@
                 restrict: 'EA',
                 scope: {
                     request: '&',
-                    showState: '&'
+                    changeStateName: '&'
                 },
                 link: function(scope, element, attr) {
                     var usMap = {
@@ -88,8 +88,7 @@
                             st[0].style.cursor = "pointer";
 
                             st[0].onmouseover = function() {
-                                // scope.showState = state;
-                                scope.showState()(state);
+                                scope.changeStateName()(state);
                                 st.animate({
                                     fill: "#2EA2DA"
                                 }, 200);
@@ -103,12 +102,12 @@
                                 }, 200);
                                 st.toFront();
                                 R.safari();
-                                scope.showState()('');
+                                scope.changeStateName()('');
                             };
 
                             st[0].onclick = function() {
                                 scope.request()(state);
-                            }
+                            };
 
                         })(usRaphael[state], state);
                     }

--- a/public/scripts/services/stateService.js
+++ b/public/scripts/services/stateService.js
@@ -47,12 +47,20 @@
                     } else {
                         stateReps.push(arr[i]);
                     }
+                    if(arr[i].channels){
+                        for(var j = 0; j < arr[i].channels.length; j++){
+                            if(arr[i].channels[j].type === "Facebook")
+                                arr[i].facebook = arr[i].channels[j].id;
+                            else if(arr[i].channels[j].type === "Twitter")
+                                arr[i].twitter = arr[i].channels[j].id;
+                        }
+                    }
 
                 }
                 fixPicture(local);
                 fixPicture(national);
                 fixPicture(stateReps);
-                return response.data;
+                return [national, stateReps, local];
             });
         }
 

--- a/public/views/map.html
+++ b/public/views/map.html
@@ -1,5 +1,5 @@
 <div class="map-container">
-	<map-area id="container" request="mapCtrl.setCurrentState" show-state="mapCtrl.showCurrentState"></map-area>
-	<p class="show-state" ng-hide="mapCtrl.hideState">{{mapCtrl.showState}}</p>
+	<map-area id="container" request="mapCtrl.setCurrentState" change-state-name="mapCtrl.changeStateName"></map-area>
+	<p class="show-state" ng-hide="mapCtrl.hideState">{{mapCtrl.stateName}}</p>
 	<p class="show-state" ng-show="mapCtrl.showSpinner"><i class='ion-loading-c'></i></p>
 </div>

--- a/public/views/stateInfo.html
+++ b/public/views/stateInfo.html
@@ -24,9 +24,9 @@
                         <ul class="social-list">
                             <li class="rep-data"><a href="#"><i class="ion-ios7-email-outline email-icon"></i></a>
                             </li>
-                            <li class="rep-data"><a href="http://twitter.com/{{rep.channels[0].id}}" target="_blank"><i class="ion-social-twitter-outline twitter-icon"></i></a>
+                            <li ng-if="rep.twitter" class="rep-data"><a href="http://twitter.com/{{rep.twitter}}" target="_blank"><i class="ion-social-twitter-outline twitter-icon"></i></a>
                             </li>
-                            <li class="rep-data"><a href="http://facebook.com/{{rep.channels[1].id}}" target="_blank"><i class="ion-social-facebook-outline facebook-icon"></i></a>
+                            <li ng-if="rep.facebook" class="rep-data"><a href="http://facebook.com/{{rep.facebook}}" target="_blank"><i class="ion-social-facebook-outline facebook-icon"></i></a>
                             </li>
                             <li class="rep-data"><a href="{{rep.urls[0]}}" target="_blank"><i class="ion-ios7-world-outline website-icon"></i></a>
                             </li>
@@ -52,9 +52,9 @@
                         <ul class="social-list">
                             <li class="rep-data"><a href="#"><i class="ion-ios7-email-outline email-icon"></i></a>
                             </li>
-                            <li class="rep-data"><a href="http://twitter.com/{{rep.channels[0].id}}" target="_blank"><i class="ion-social-twitter-outline twitter-icon"></i></a>
+                            <li ng-if="rep.twitter" class="rep-data"><a href="http://twitter.com/{{rep.twitter}}" target="_blank"><i class="ion-social-twitter-outline twitter-icon"></i></a>
                             </li>
-                            <li class="rep-data"><a href="http://facebook.com/{{rep.channels[1].id}}" target="_blank"><i class="ion-social-facebook-outline facebook-icon"></i></a>
+                            <li ng-if="rep.facebook" class="rep-data"><a href="http://facebook.com/{{rep.facebook}}" target="_blank"><i class="ion-social-facebook-outline facebook-icon"></i></a>
                             </li>
                             <li class="rep-data"><a href="{{rep.urls[0]}}" target="_blank"><i class="ion-ios7-world-outline website-icon"></i></a>
                             </li>
@@ -80,9 +80,9 @@
                         <ul class="social-list">
                             <li class="rep-data"><a href="#"><i class="ion-ios7-email-outline email-icon"></i></a>
                             </li>
-                            <li class="rep-data"><a href="http://twitter.com/{{rep.channels[0].id}}" target="_blank"><i class="ion-social-twitter-outline twitter-icon"></i></a>
+                            <li ng-if="rep.twitter" class="rep-data"><a href="http://twitter.com/{{rep.twitter}}" target="_blank"><i class="ion-social-twitter-outline twitter-icon"></i></a>
                             </li>
-                            <li class="rep-data"><a href="http://facebook.com/{{rep.channels[1].id}}" target="_blank"><i class="ion-social-facebook-outline facebook-icon"></i></a>
+                            <li ng-if="rep.facebook" class="rep-data"><a href="http://facebook.com/{{rep.facebook}}" target="_blank"><i class="ion-social-facebook-outline facebook-icon"></i></a>
                             </li>
                             <li class="rep-data"><a href="{{rep.urls[0]}}" target="_blank"><i class="ion-ios7-world-outline website-icon"></i></a>
                             </li>


### PR DESCRIPTION
The links for facebook and twitter accounts were not loading correctly. I fixed that. Also, I hid facebook or twitter buttons when the candidate did not have any facebook or twitter account. Some styling may be in order.

BTW, the api actually does not bring in email addresses for the reps. We probably should nix the email idea.
